### PR TITLE
Adds additional -f option for mailmq sendmail interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Add the following to your `php.ini` to use with PHP:
 sendmail_path = "mailmq -t"
 ```
 
+Tests
+-----
+
+# Install PHPUnit locally, with an appropriate version of PHP also installed 
+  and available locally
+# Have python3 available locally (using virtualenv or similar)
+# Install celery locally with `pip install -r requirements.txt`
+# `./tests/run.sh` - this will start up the required docker containers, and
+  configure PHP to use mailmq for sendmail, then run the phpunit tests.
+
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ Add the following to your `php.ini` to use with PHP:
 sendmail_path = "mailmq -t"
 ```
 
-Tests
------
+Running Tests Locally
+---------------------
 
-# Install PHPUnit locally, with an appropriate version of PHP also installed 
-  and available locally
-# Have python3 available locally (using virtualenv or similar)
+# Install PHPUnit, with an appropriate version of PHP also installed 
+  and available locally.
+# Make python3 available. you might have to use virtualenv to do this. 
+  e.g. `mkvirtualenv --python=python3 .`
 # Install celery locally with `pip install -r requirements.txt`
-# `./tests/run.sh` - this will start up the required docker containers, and
-  configure PHP to use mailmq for sendmail, then run the phpunit tests.
+# `./tests/run.sh` - this starts up the required docker containers,
+  configures PHP to use mailmq for sending email, then runs the phpunit
+  tests defined in /tests
 
 
 License

--- a/mailmq/client/__init__.py
+++ b/mailmq/client/__init__.py
@@ -13,7 +13,7 @@ from ..server import sendmail
 def main():
     """Main entrypoint."""
     parser = argparse.ArgumentParser(description="Send an email via Celery/MQ.")
-    parser.add_argument('-r', dest='sender', type=str,
+    parser.add_argument('-r', '-f', dest='sender', type=str,
                         help="Set the envelope sender address.")
     parser.add_argument('-t', dest='extract_recipients', action='store_true',
                         help="Extract recipients.")

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -9,4 +9,13 @@ class MailTest extends TestCase
              "Snake",
              "Mushroom");
     }
+
+    public function testSendMailAdditionalOption()
+    {
+        mail("badger@example.com",
+             "Snake",
+             "Mushroom",
+             null,
+             "-fbigbadger@example.com");
+    }
 }


### PR DESCRIPTION
This is functionally identical to setting -r so the from/sender address can now be set using either -r or -f. 

Resolves issue with php sendmail interface expecting to be able to set -f option. 